### PR TITLE
feat(pool): integrate priority scheduling with ThreadPool

### DIFF
--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -208,6 +208,23 @@ impl JobQueue for PriorityJobQueue {
             exact_size: true,
         }
     }
+
+    fn send_with_priority(&self, job: BoxedJob, priority: Priority) -> QueueResult<()> {
+        PriorityJobQueue::send_with_priority(self, job, priority)
+    }
+
+    fn try_send_with_priority(&self, job: BoxedJob, priority: Priority) -> QueueResult<()> {
+        PriorityJobQueue::try_send_with_priority(self, job, priority)
+    }
+
+    fn send_with_priority_timeout(
+        &self,
+        job: BoxedJob,
+        priority: Priority,
+        timeout: Duration,
+    ) -> QueueResult<()> {
+        PriorityJobQueue::send_with_priority_timeout(self, job, priority, timeout)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR completes the integration of priority scheduling with ThreadPool, addressing issue #4.

- Add `enable_priority()` config option to `ThreadPoolConfig` for easy priority queue setup
- Add `submit_with_priority()` and `execute_with_priority()` methods to `ThreadPool`
- Add `send_with_priority()` trait methods to `JobQueue` with default implementations
- Override priority methods in `PriorityJobQueue` to use actual priority ordering
- Add comprehensive unit tests verifying priority ordering behavior
- Update README with priority scheduling documentation and examples

## Changes

### ThreadPoolConfig
- New `enable_priority` field (feature-gated with `priority-scheduling`)
- New `enable_priority(bool)` builder method

### ThreadPool
- New `submit_with_priority()` method for submitting jobs with explicit priority
- New `execute_with_priority()` method for executing closures with priority
- Modified `start()` to create `PriorityJobQueue` when `enable_priority` is true

### JobQueue trait
- New `send_with_priority()` method with default impl (falls back to `send()`)
- New `try_send_with_priority()` method with default impl
- New `send_with_priority_timeout()` method with default impl

### PriorityJobQueue
- Override trait methods to use actual priority ordering

## Test plan

- [x] All existing tests pass (81 unit tests, 7 cancellation tests, 15 property tests)
- [x] New priority ordering tests pass
- [x] Build passes with and without `priority-scheduling` feature
- [x] Clippy passes with no warnings
- [x] `test_priority_ordering` verifies Critical > High > Normal > Low ordering

## Example Usage

```rust
use rust_thread_system::prelude::*;

let config = ThreadPoolConfig::new(4).enable_priority(true);
let pool = ThreadPool::with_config(config)?;
pool.start()?;

// Critical jobs processed first
pool.execute_with_priority(|| {
    println!("Critical task");
    Ok(())
}, Priority::Critical)?;

// Low priority jobs processed last
pool.execute_with_priority(|| {
    println!("Background task");
    Ok(())
}, Priority::Low)?;
```

Closes #4