### PR TITLE
feat(queue): add capability introspection system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "rust_thread_system"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "criterion",
  "crossbeam",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ crossbeam = "0.8"
 parking_lot = "0.12"
 thiserror = "2.0"
 num_cpus = "1.16"
+bitflags = "2.6"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,10 @@ pub use pool::{ThreadPool, ThreadPoolConfig, WorkerStats};
 #[cfg(feature = "priority-scheduling")]
 pub use queue::PriorityJobQueue;
 pub use queue::{
-    BackpressureHandler, BackpressureStats, BackpressureStatsSnapshot, BackpressureStrategy,
-    BoundedQueue, ChannelQueue, JobQueue, QueueCapabilities, QueueError, QueueFactory,
-    QueueRequirements, QueueResult,
+    require_capabilities, BackpressureHandler, BackpressureStats, BackpressureStatsSnapshot,
+    BackpressureStrategy, BoundedQueue, CapabilityFlags, ChannelQueue, JobQueue,
+    MissingCapabilitiesError, QueueCapabilities, QueueError, QueueFactory, QueueRequirements,
+    QueueResult,
 };
 pub use typed::{
     DefaultJobType, JobType, TypeStats, TypedClosureJob, TypedJob, TypedPoolConfig, TypedThreadPool,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,8 @@ pub use crate::pool::{ThreadPool, ThreadPoolConfig, WorkerStats};
 #[cfg(feature = "priority-scheduling")]
 pub use crate::queue::PriorityJobQueue;
 pub use crate::queue::{
-    BoundedQueue, ChannelQueue, JobQueue, QueueCapabilities, QueueError, QueueResult,
+    require_capabilities, BoundedQueue, CapabilityFlags, ChannelQueue, JobQueue,
+    MissingCapabilitiesError, QueueCapabilities, QueueError, QueueResult,
 };
 pub use crate::typed::{
     DefaultJobType, JobType, TypeStats, TypedClosureJob, TypedJob, TypedPoolConfig, TypedThreadPool,

--- a/src/queue/adaptive.rs
+++ b/src/queue/adaptive.rs
@@ -620,8 +620,15 @@ impl JobQueue for AdaptiveQueue {
             is_bounded: false,
             capacity: None,
             is_lock_free: self.current_strategy() == QueueStrategy::LockFree,
+            is_wait_free: false,
             supports_priority: false,
             exact_size: false,
+            mpmc: true,
+            spsc: false,
+            supports_blocking: true,
+            supports_timeout: true,
+            is_adaptive: true,
+            implementation_name: "AdaptiveQueue",
         }
     }
 }
@@ -761,7 +768,15 @@ mod tests {
         let caps = queue.capabilities();
         assert!(!caps.is_bounded);
         assert!(caps.capacity.is_none());
+        assert!(!caps.is_wait_free);
         assert!(!caps.supports_priority);
+        assert!(!caps.exact_size);
+        assert!(caps.mpmc);
+        assert!(!caps.spsc);
+        assert!(caps.supports_blocking);
+        assert!(caps.supports_timeout);
+        assert!(caps.is_adaptive);
+        assert_eq!(caps.implementation_name, "AdaptiveQueue");
     }
 
     #[test]

--- a/src/queue/bounded.rs
+++ b/src/queue/bounded.rs
@@ -146,13 +146,7 @@ impl JobQueue for BoundedQueue {
     }
 
     fn capabilities(&self) -> QueueCapabilities {
-        QueueCapabilities {
-            is_bounded: true,
-            capacity: Some(self.capacity),
-            is_lock_free: true,
-            supports_priority: false,
-            exact_size: false,
-        }
+        QueueCapabilities::bounded_channel(self.capacity)
     }
 }
 
@@ -301,8 +295,15 @@ mod tests {
         assert!(caps.is_bounded);
         assert_eq!(caps.capacity, Some(100));
         assert!(caps.is_lock_free);
+        assert!(!caps.is_wait_free);
         assert!(!caps.supports_priority);
         assert!(!caps.exact_size);
+        assert!(caps.mpmc);
+        assert!(!caps.spsc);
+        assert!(caps.supports_blocking);
+        assert!(caps.supports_timeout);
+        assert!(!caps.is_adaptive);
+        assert_eq!(caps.implementation_name, "crossbeam::channel::bounded");
     }
 
     #[test]

--- a/src/queue/channel.rs
+++ b/src/queue/channel.rs
@@ -118,13 +118,7 @@ impl JobQueue for ChannelQueue {
     }
 
     fn capabilities(&self) -> QueueCapabilities {
-        QueueCapabilities {
-            is_bounded: false,
-            capacity: None,
-            is_lock_free: true,
-            supports_priority: false,
-            exact_size: false,
-        }
+        QueueCapabilities::unbounded_channel()
     }
 }
 
@@ -226,8 +220,15 @@ mod tests {
         assert!(!caps.is_bounded);
         assert!(caps.capacity.is_none());
         assert!(caps.is_lock_free);
+        assert!(!caps.is_wait_free);
         assert!(!caps.supports_priority);
         assert!(!caps.exact_size);
+        assert!(caps.mpmc);
+        assert!(!caps.spsc);
+        assert!(caps.supports_blocking);
+        assert!(caps.supports_timeout);
+        assert!(!caps.is_adaptive);
+        assert_eq!(caps.implementation_name, "crossbeam::channel::unbounded");
     }
 
     #[test]

--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -200,13 +200,7 @@ impl JobQueue for PriorityJobQueue {
     }
 
     fn capabilities(&self) -> QueueCapabilities {
-        QueueCapabilities {
-            is_bounded: false,
-            capacity: None,
-            is_lock_free: false,
-            supports_priority: true,
-            exact_size: true,
-        }
+        QueueCapabilities::priority_queue(None)
     }
 
     fn send_with_priority(&self, job: BoxedJob, priority: Priority) -> QueueResult<()> {
@@ -353,8 +347,15 @@ mod tests {
         assert!(!caps.is_bounded);
         assert!(caps.capacity.is_none());
         assert!(!caps.is_lock_free);
+        assert!(!caps.is_wait_free);
         assert!(caps.supports_priority);
         assert!(caps.exact_size);
+        assert!(caps.mpmc);
+        assert!(!caps.spsc);
+        assert!(caps.supports_blocking);
+        assert!(caps.supports_timeout);
+        assert!(!caps.is_adaptive);
+        assert_eq!(caps.implementation_name, "PriorityJobQueue");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add comprehensive queue capability introspection system for runtime querying of queue characteristics
- Introduce `CapabilityFlags` bitflags for specifying required capabilities
- Extend `QueueCapabilities` struct with additional fields (is_wait_free, mpmc, spsc, etc.)
- Add `describe()` and `satisfies()` methods to `QueueCapabilities`
- Add `supports()` convenience method to `JobQueue` trait
- Add `require_capabilities()` validation function with `MissingCapabilitiesError`
- Add `queue_capabilities()` and `supports_capabilities()` methods to `ThreadPool`
- Update all queue implementations with accurate capability reporting
- Add comprehensive unit tests for all new functionality
- Update README documentation in both English and Korean

## Changes

### New Types
- `CapabilityFlags`: Bitflags for specifying required queue capabilities
- `MissingCapabilitiesError`: Error type for capability validation failures

### Extended Types
- `QueueCapabilities`: Added 7 new fields (is_wait_free, mpmc, spsc, supports_blocking, supports_timeout, is_adaptive, implementation_name)
- `QueueCapabilities`: Added factory methods (unbounded_channel, bounded_channel, priority_queue, adaptive)
- `QueueCapabilities`: Added `describe()` and `satisfies()` methods

### New Methods
- `JobQueue::supports()`: Convenience method for capability checking
- `ThreadPool::queue_capabilities()`: Get underlying queue capabilities
- `ThreadPool::supports_capabilities()`: Check pool queue capabilities
- `require_capabilities()`: Validate queue meets requirements

### Dependencies
- Added `bitflags = "2.6"` for CapabilityFlags implementation

## Test plan

- [x] All existing tests pass (219 tests)
- [x] New unit tests for QueueCapabilities methods
- [x] New unit tests for CapabilityFlags combinations
- [x] New unit tests for require_capabilities function
- [x] New unit tests for JobQueue::supports method
- [x] Clippy passes with no warnings
- [x] Code formatted with rustfmt

Closes #11